### PR TITLE
Reformat post metadata

### DIFF
--- a/content/posts/principles.md
+++ b/content/posts/principles.md
@@ -1,9 +1,11 @@
-+++
-title = "RecipeRadar"
-author = "James"
-tags = ["company", "culture", "principles"]
-showFullContent = true
-+++
+---
+title: RecipeRadar
+author: James
+tags:
+- company
+- culture
+- principles
+---
 RecipeRadar aims to provide recipe search, meal planning, and cooking guidance
 to a global audience via services which are simple, intuitive, collaborative
 and effective, and always designed with users as our first priority.

--- a/content/posts/welcome.md
+++ b/content/posts/welcome.md
@@ -1,9 +1,11 @@
-+++
-title = "Welcome!"
-author = "James"
-tags = ["announcements", "welcome", "engineering"]
-showFullContent = true
-+++
+---
+title: Welcome!
+author: James
+tags:
+- announcements
+- welcome
+- engineering
+---
 The [engineering](/tags/engineering) tag will be the home for a series of
 articles detailing the engineering effort behind building RecipeRadar, a recipe
 search engine and meal planner.


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
@.qqhann's [yaml-like](https://github.com/qqhann/blog/blame/3563973d4f56b159f54ea6f664dee84b78659820/content/blog/diy-pc.md#L1-L8) metadata format for blog post metadata is an improvement over the existing RecipeRadar blog post metadata.

In particular, it places tags on separate lines, which is generally preferably for any list of items that may be viewed in diff tools.

### Briefly summarize the changes
1. Update metadata format on blog posts

### How have the changes been tested?
1. Tested via `hugo && hugo server` locally

**List any issues that this change relates to**
Fixes # .
