### PR TITLE
Correctly backdate 'welcome' post

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ fullWidthTheme = false
 centerTheme = false
 
 [frontmatter]
-date = [":git"]
+date = ["date", ":git"]
 
 [languages]
   [languages.en]

--- a/content/posts/welcome.md
+++ b/content/posts/welcome.md
@@ -1,5 +1,6 @@
 ---
 title: Welcome!
+date: 2019-10-29T13:13:48-07:00
 author: James
 tags:
 - announcements


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Since the `welcome` post was modified in `git`, the published article date was incorrectly updated.  Here we make sure that the original, most accurate original publish date is displayed, despite subsequent edits.

### Briefly summarize the changes
1. Configure hugo to allow post `date` metadata to override `git` modification time

### How have the changes been tested?
1. Locally via `hugo && hugo server`

**List any issues that this change relates to**
Relates to #7 