### PR TITLE
Rebrand blog & update copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# RecipeRadar Engineering Blog
+# RecipeRadar Blog
 
-The RecipeRadar engineering blog is used to share updates and background about the technology and functionality behind the application.
+The RecipeRadar blog is used to share updates and background about the RecipeRadar service.
 
 It's a [Hugo](https://gohugo.io) static site and posts are configured to read their timestamps from this `git` repository.
 

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ enableRobotsTXT = true
 disableHugoGeneratorInject = true
 languageCode = "en-us"
 theme = "primer"
-title = "RecipeRadar Engineering"
+title = "RecipeRadar Blog"
 
 [params]
 themeColor = "blue"
@@ -17,14 +17,14 @@ date = ["date", ":git"]
 [languages]
   [languages.en]
     languageName = "English"
-    title = "RecipeRadar Engineering"
-    subtitle = "The technology behind the recipe search engine"
-    keywords = "recipes, software, engineering, technology"
+    title = "RecipeRadar Blog"
+    subtitle = "News and articles relating to the RecipeRadar search engine"
+    keywords = "recipes, software, news, technology"
     copyright = "&copy; RecipeRadar"
     menuMore = "Show more"
     readMore = "Read more"
     readOtherPosts = "Read other posts"
 
     [languages.en.params.logo]
-      logoText = "RecipeRadar Engineering"
+      logoText = "RecipeRadar Blog"
       logoHomeLink = "/"

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ date = ['date', ':git']
     title = 'RecipeRadar Blog'
     subtitle = 'News and articles relating to the RecipeRadar search engine'
     keywords = 'recipes, software, news, technology'
-    copyright = '&copy; RecipeRadar'
+    copyright = '&copy; <a href="https://beta.companieshouse.gov.uk/company/SC647817">OpenCulinary C.I.C.</a> 2019 &ndash; 2020'
     menuMore = 'Show more'
     readMore = 'Read more'
     readOtherPosts = 'Read other posts'

--- a/config.toml
+++ b/config.toml
@@ -1,30 +1,30 @@
-baseURL = "https://blog.reciperadar.com"
+baseURL = 'https://blog.reciperadar.com'
 enableGitInfo = true
 enableRobotsTXT = true
 disableHugoGeneratorInject = true
-languageCode = "en-us"
-theme = "primer"
-title = "RecipeRadar Blog"
+languageCode = 'en-us'
+theme = 'primer'
+title = 'RecipeRadar Blog'
 
 [params]
-themeColor = "blue"
+themeColor = 'blue'
 fullWidthTheme = false
 centerTheme = false
 
 [frontmatter]
-date = ["date", ":git"]
+date = ['date', ':git']
 
 [languages]
   [languages.en]
-    languageName = "English"
-    title = "RecipeRadar Blog"
-    subtitle = "News and articles relating to the RecipeRadar search engine"
-    keywords = "recipes, software, news, technology"
-    copyright = "&copy; RecipeRadar"
-    menuMore = "Show more"
-    readMore = "Read more"
-    readOtherPosts = "Read other posts"
+    languageName = 'English'
+    title = 'RecipeRadar Blog'
+    subtitle = 'News and articles relating to the RecipeRadar search engine'
+    keywords = 'recipes, software, news, technology'
+    copyright = '&copy; RecipeRadar'
+    menuMore = 'Show more'
+    readMore = 'Read more'
+    readOtherPosts = 'Read other posts'
 
     [languages.en.params.logo]
-      logoText = "RecipeRadar Blog"
-      logoHomeLink = "/"
+      logoText = 'RecipeRadar Blog'
+      logoHomeLink = '/'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The RecipeRadar blog is being rebranded to include content encompassing the entire service - see #7 for details.

### Briefly summarize the changes
1. Drop 'engineering' from the blog brand and description
1. Update the copyright notice in the footer

### How have the changes been tested?
1. Locally via `hugo && hugo server`

**List any issues that this change relates to**
Fixes #7 